### PR TITLE
fix: Add palette info on empty state

### DIFF
--- a/src/components/pages/accessibility/index.js
+++ b/src/components/pages/accessibility/index.js
@@ -57,7 +57,10 @@ const AccessibilityChecker = () => {
               <InfoModal />
             </div>
 
-            <AccessibilitySection colors={colors}>
+            <AccessibilitySection
+              key={`${colors[0]}-${colors[1]}`}
+              colors={colors}
+            >
               <InfoSwatchWithPicker
                 className="mr-3 mb-5"
                 key={colors[0]}

--- a/src/components/pages/palette/index.js
+++ b/src/components/pages/palette/index.js
@@ -7,11 +7,13 @@ import { deleteItemByIndex, updateItemByIndex } from "../../../utils/array";
 import { formatColorSearchParams } from "../../../utils/routing";
 import InfoSwatchWithPicker from "../../swatches/info-with-color-picker";
 import AddButton from "./add-button";
+import ShareButton from "./share-button";
 
 const ColorPalette = () => {
   const navigate = useNavigate();
   const addRecentColor = useRecentColorsDispatch();
   const [colors, setColors] = useState(useSearchParameters());
+  const hasColors = !!colors.length;
 
   const handleColorUpdate = updatedColors => {
     navigate(formatColorSearchParams(updatedColors), { replace: true });
@@ -36,9 +38,17 @@ const ColorPalette = () => {
   };
 
   return (
-    <StyledWrapper>
-      {colors.length
-        ? colors.map((color, index) => (
+    <StyledContainer>
+      {hasColors ? (
+        <StyledButton>Share</StyledButton>
+      ) : (
+        <h1 className="subtitle is-size-3-desktop is-size-4-touch has-text-centered">
+          Create and share your color palette.
+        </h1>
+      )}
+      <StyledWrapper>
+        {hasColors &&
+          colors.map((color, index) => (
             <InfoSwatchWithPicker
               className="mr-3 mb-3"
               key={`${color}-${index}`}
@@ -46,23 +56,33 @@ const ColorPalette = () => {
               onUpdate={updateColor(index)}
               onDelete={deleteColor(index)}
             />
-          ))
-        : null}
-      <AddButton
-        initColor={colors[colors.length - 1]}
-        onAddColor={addNewColor}
-      />
-    </StyledWrapper>
+          ))}
+        <AddButton
+          initColor={colors[colors.length - 1]}
+          onAddColor={addNewColor}
+        />
+      </StyledWrapper>
+    </StyledContainer>
   );
 };
 
 export default ColorPalette;
 
+const StyledContainer = styled.div`
+  padding 2rem 0;
+`;
+
 const StyledWrapper = styled.div`
   align-items: center;
-  box-sizing: border-box; 
+  box-sizing: border-box;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  padding 2rem 0;
+`;
+
+const StyledButton = styled(ShareButton)`
+  bottom: 0.5rem;
+  position: fixed;
+  right: 0.5rem;
+  z-index: 1;
 `;

--- a/src/components/pages/palette/share-button.js
+++ b/src/components/pages/palette/share-button.js
@@ -1,0 +1,60 @@
+import { useLocation } from "@reach/router";
+import copy from "copy-to-clipboard";
+import PropTypes from "prop-types";
+import React, { useEffect, useState } from "react";
+import cn from "../../../utils/cn";
+import { Icon, IconWrapper } from "../../icon";
+
+const delay = 2000;
+const shareData = {
+  className: "is-link",
+  disabled: false,
+  icon: "fas fa-share",
+  text: "Share",
+};
+const copyData = {
+  className: "is-dark",
+  disabled: true,
+  icon: "fas fa-check",
+  text: "Copied!",
+};
+
+const ShareButton = ({ className, ...props }) => {
+  const { href } = useLocation();
+  const [button, setButton] = useState(shareData);
+  let timeout;
+
+  const onClick = () => {
+    copy(href, { format: "text/plain" });
+    setButton(copyData);
+    timeout = setTimeout(() => {
+      setButton(shareData);
+    }, delay);
+  };
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [timeout]);
+
+  return (
+    <button
+      className={cn("button", button.className, className)}
+      disabled={button.disabled}
+      onClick={onClick}
+      {...props}
+    >
+      <IconWrapper key={button.icon} size="small">
+        <Icon aria-hidden="true" icon={button.icon} />
+      </IconWrapper>
+      <span>{button.text}</span>
+    </button>
+  );
+};
+
+export default ShareButton;
+
+ShareButton.propTypes = {
+  className: PropTypes.string,
+};


### PR DESCRIPTION
This code:
* Adds info explaining what the palette page does when it's empty
* Adds a URL share button to the palette page when colors have been selected.